### PR TITLE
Pull in basic concurrency tools from tine.

### DIFF
--- a/src/Twine.hs
+++ b/src/Twine.hs
@@ -1,3 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Twine (
+    module Twine.Data
+  , module Twine.Snooze
   ) where
+
+import           Twine.Data
+import           Twine.Snooze

--- a/src/Twine/Data.hs
+++ b/src/Twine/Data.hs
@@ -1,0 +1,7 @@
+module Twine.Data (
+    module Twine.Data.Duration
+  , module Twine.Data.Pin
+  ) where
+
+import           Twine.Data.Duration
+import           Twine.Data.Pin

--- a/src/Twine/Data/Duration.hs
+++ b/src/Twine/Data/Duration.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Twine.Data.Duration (
+    Duration
+  , microseconds
+  , milliseconds
+  , seconds
+  , minutes
+  , toMicroseconds
+  , toMilliseconds
+  , toMinutes
+  , toSeconds
+  ) where
+
+import           P
+
+-- |
+-- A Duration is an abstract type, representing a short delay (in the
+-- region of micro-seconds to a few minutes).
+--
+-- This useful for implementing concurrency and process primitives
+-- that need to wait for short periods to ensure fairness (for example).
+--
+newtype Duration =
+  Duration {
+      duration :: Int
+    } deriving (Eq, Show)
+
+microseconds :: Int -> Duration
+microseconds =
+  Duration
+
+milliseconds :: Int -> Duration
+milliseconds =
+  microseconds . (*) 1000
+
+seconds :: Int -> Duration
+seconds =
+  milliseconds . (*) 1000
+
+minutes :: Int -> Duration
+minutes =
+  seconds . (*) 60
+
+toMicroseconds :: Duration -> Int
+toMicroseconds =
+  duration
+
+toMilliseconds :: Duration -> Int
+toMilliseconds =
+  flip div 1000 . toMicroseconds
+
+toSeconds :: Duration -> Int
+toSeconds =
+  flip div 1000 . toMilliseconds
+
+toMinutes :: Duration -> Int
+toMinutes =
+  flip div 60 . toSeconds

--- a/src/Twine/Data/Pin.hs
+++ b/src/Twine/Data/Pin.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Twine.Data.Pin (
+    Pin
+  , newPin
+  , checkPin
+  , pullPin
+  ) where
+
+import           Control.Concurrent.MVar
+
+import           P
+
+import           System.IO
+
+-- |
+-- A pin is an abstract type, representing a simple barrier
+-- that can only have its state queried in a non-blocking
+-- manner.
+--
+-- This useful for implementing things like passing in a hook
+-- to terminate or stop waiting for a process.
+--
+newtype Pin =
+  Pin { pin :: MVar () }
+
+newPin :: IO Pin
+newPin =
+  Pin <$> newEmptyMVar
+
+checkPin :: Pin -> IO Bool
+checkPin =
+  fmap isJust . tryTakeMVar . pin
+
+pullPin :: Pin -> IO ()
+pullPin =
+  void . flip tryPutMVar () . pin

--- a/src/Twine/Snooze.hs
+++ b/src/Twine/Snooze.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Twine.Snooze (
+    snooze
+  , module Twine.Data.Duration
+  ) where
+
+import           Control.Concurrent
+
+import           P
+
+import           System.IO
+
+import           Twine.Data.Duration
+
+
+snooze :: Duration -> IO ()
+snooze =
+  threadDelay . toMicroseconds

--- a/test/Test/IO/Twine/Snooze.hs
+++ b/test/Test/IO/Twine/Snooze.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.IO.Twine.Snooze where
+
+import           Data.Time
+
+import           Disorder.Core.IO
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+import           Twine.Snooze
+
+
+prop_snooze = forAll (choose (1, 3)) $ \n -> testIO $ do
+  s <- getCurrentTime
+  snooze . seconds $ n
+  e <- getCurrentTime
+  let elapsed = diffUTCTime e s
+  let expected = (fromInteger . toInteger) n
+  pure . counterexample ("Elapsed: " <> show elapsed <> " , Snooze: " <> show expected) $
+    elapsed >= expected && elapsed < expected + 1
+
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 3 })

--- a/test/Test/Twine/Data/Duration.hs
+++ b/test/Test/Twine/Data/Duration.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Twine.Data.Duration where
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+import           Twine.Data.Duration
+
+--
+-- Symmetric conversions
+--
+
+prop_microseconds n =
+  toMicroseconds (microseconds n) === n
+
+prop_milliseconds n =
+  toMilliseconds (milliseconds n) === n
+
+prop_seconds n =
+  toSeconds (seconds n) === n
+
+prop_minutes n =
+  toMinutes (minutes n) === n
+
+--
+-- Scaling
+--
+
+prop_microseconds_scale n =
+  toMicroseconds (microseconds n) === n
+
+prop_milliseconds_scale n =
+  toMicroseconds (milliseconds n) === (n * 1000)
+
+prop_seconds_scale n =
+  toMicroseconds (seconds n) === (n * 1000 * 1000)
+
+prop_minutes_scale n =
+  toMicroseconds (minutes n) === (n * 60 * 1000 * 1000)
+
+--
+-- Sanity checks
+--
+
+prop_sanity = conjoin [
+    minutes 1 === seconds 60
+  , seconds 1 === milliseconds 1000
+  , milliseconds 1 === microseconds 1000
+  ]
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/test/Test/Twine/Data/Pin.hs
+++ b/test/Test/Twine/Data/Pin.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Twine.Data.Pin where
+
+import           Disorder.Core.IO
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+import           Twine.Data.Pin
+
+
+--
+-- We are really just testing that our restricted use of MVar
+-- is safe. The point of wrapping it up is preventing dead/live
+-- locks, and generally make it more pleasant and less error-
+-- prone
+--
+
+
+--
+-- A new pin should not be pulled
+--
+
+prop_new = once . testIO $
+  newPin >>= checkPin >>= pure . (===) False
+
+
+--
+-- A pulled pin should be pulled
+--
+
+prop_pull = once . testIO $
+  newPin >>= \p -> pullPin p >> checkPin p >>= pure . (===) True
+
+
+--
+-- A pin can be pulled multiple tiumes without blocking
+--
+
+prop_pull_pull = once . testIO $
+  newPin >>= \p -> pullPin p >> pullPin p >> checkPin p >>= pure . (===) True
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,0 +1,10 @@
+import           Disorder.Core.Main
+
+import           Test.IO.Twine.Snooze
+
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.IO.Twine.Snooze.tests
+    ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,6 +1,11 @@
 import           Disorder.Core.Main
 
+import           Test.Twine.Data.Duration
+import           Test.Twine.Data.Pin
+
 main :: IO ()
 main =
   disorderMain [
+      Test.Twine.Data.Duration.tests
+    , Test.Twine.Data.Pin.tests
     ]

--- a/twine.cabal
+++ b/twine.cabal
@@ -15,6 +15,7 @@ library
                        base                            >= 3          && < 5
                      , either                          == 4.3.*
                      , p
+                     , time                            == 1.4.*
 
   ghc-options:
                        -Wall
@@ -25,6 +26,10 @@ library
 
   exposed-modules:
                        Twine
+                       Twine.Data
+                       Twine.Data.Duration
+                       Twine.Data.Pin
+                       Twine.Snooze
 
 test-suite test
   type:                exitcode-stdio-1.0
@@ -41,5 +46,25 @@ test-suite test
                      , twine
                      , disorder-core
                      , p
+                     , time
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*
+
+test-suite test-io
+  type:                exitcode-stdio-1.0
+
+  main-is:             test-io.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , twine
+                     , disorder-core
+                     , p
+                     , time
                      , QuickCheck                      == 2.7.*
                      , quickcheck-instances            == 0.3.*


### PR DESCRIPTION
The thinking here is that tine is going to have to depend on twine, so options are a general library of "bits" or twine has the core concurrency concepts and tine re-exports. I am suggesting we go with the latter. Thoughts? 
