### PR TITLE
Add default capability block.

### DIFF
--- a/src/Twine/Capability.hs
+++ b/src/Twine/Capability.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Twine.Capability (
+    defaultCapability
+  ) where
+
+
+import           Control.Concurrent (getNumCapabilities, setNumCapabilities)
+
+import           GHC.Conc (getNumProcessors)
+
+import           P
+
+import           System.IO
+
+
+
+-- |
+-- Default capabilities to number of processors if it is still at default of 1.
+--
+defaultCapability :: IO ()
+defaultCapability = do
+  x <- getNumCapabilities
+  when (x == 1) $
+    getNumProcessors >>= setNumCapabilities


### PR DESCRIPTION
This or something like it is in fairly wide spread use. Would like to push it all into 1 spot and come up with a default version.

Is there a case for adding something to force it to 1? Any other better way to check if rts has been set explicitly?


@jystic @tranma @nhibberd 