### PR TITLE
Update waitForPin to use readMVar instead of take

### DIFF
--- a/src/Twine/Data/Pin.hs
+++ b/src/Twine/Data/Pin.hs
@@ -34,7 +34,7 @@ checkPin =
 
 waitForPin :: Pin -> IO ()
 waitForPin =
-  void . takeMVar . pin
+  void . readMVar . pin
 
 pullPin :: Pin -> IO ()
 pullPin =


### PR DESCRIPTION
! @markhibberd @charleso 

Idea here is that we want to be able to have multiple things waiting for a pin and to have them all succeed as opposed to only having one of them succeed. 
/jury approved @charleso